### PR TITLE
Connect first, start second

### DIFF
--- a/src/container-manager.js
+++ b/src/container-manager.js
@@ -551,13 +551,13 @@ exports.launchExportService = function () {
 				);
 			})
 			.then((exportService) => {
-				return startContainer(exportService);
-			})
-			.then((exportService) => {
 				return dockerHelper.connectToNetwork(exportService, 'databox-app-net');
 			})
 			.then((exportService) => {
 				return dockerHelper.connectToNetwork(exportService, 'databox-external');
+			})
+			.then((exportService) => {
+				return startContainer(exportService);
 			})
 			.then((exportService) => {
 				console.log('[' + name + '] Passing token to Arbiter');


### PR DESCRIPTION
May solves problem with https://github.com/me-box/databox-export-service/pull/14. Behaviour unaffected — just makes it so that the container is connected to its networks before it's started.