### PR TITLE
Allow pinning of repo and branch for testing

### DIFF
--- a/databox-components
+++ b/databox-components
@@ -1,4 +1,3 @@
-core-container-manager https://github.com/me-box/core-container-manager.git master
 core-arbiter https://github.com/me-box/core-arbiter.git master
 core-export-service https://github.com/me-box/core-export-service.git master
 store-json https://github.com/me-box/store-json.git master
@@ -13,3 +12,4 @@ driver-phillips-hue https://github.com/me-box/driver-phillips-hue.git master
 driver-tplink-smart-plug https://github.com/me-box/driver-tplink-smart-plug.git master
 app-light-graph https://github.com/me-box/app-light-graph.git master
 app-twitter-sentiment https://github.com/me-box/app-twitter-sentiment.git master
+core-container-manager https://github.com/me-box/core-container-manager master

--- a/databox-components
+++ b/databox-components
@@ -1,0 +1,15 @@
+core-container-manager https://github.com/me-box/core-container-manager.git master
+core-arbiter https://github.com/me-box/core-arbiter.git master
+core-export-service https://github.com/me-box/core-export-service.git master
+store-json https://github.com/me-box/store-json.git master
+store-timeseries https://github.com/me-box/store-timeseries.git master
+platform-app-server https://github.com/me-box/platform-app-server.git master
+driver-os-monitor https://github.com/me-box/driver-os-monitor.git master
+app-os-monitor https://github.com/me-box/app-os-monitor.git master
+driver-twitter https://github.com/me-box/driver-twitter.git master
+driver-sensingkit https://github.com/me-box/driver-sensingkit.git master
+driver-google-takeout https://github.com/me-box/driver-google-takeout.git master
+driver-phillips-hue https://github.com/me-box/driver-phillips-hue.git master
+driver-tplink-smart-plug https://github.com/me-box/driver-tplink-smart-plug.git master
+app-light-graph https://github.com/me-box/app-light-graph.git master
+app-twitter-sentiment https://github.com/me-box/app-twitter-sentiment.git master

--- a/databox-fetch-components
+++ b/databox-fetch-components
@@ -1,62 +1,32 @@
 #!/usr/bin/env bash
 
-#set this to ssh if you want to clone over ssh rather then https
-UPDATE_TYPE=""
-
 update_repo()
 {
-
-    if [ "$UPDATE_TYPE" = "ssh" ]
-    then
-        update_repo_ssh $1
-    else    
-        update_repo_https $1
-    fi
-}
-
-update_repo_https()
-{
 	NAME=$1
-	REPO="https://github.com/me-box/${NAME}.git"
-
+	REPO=$2
+    BRANCH=$3
+    
 	if [ ! -d ${NAME} ]; then
+        echo "Pulling ${NAME} FROM ${REPO} on branch ${BRANCH}"
         git clone ${REPO} ${NAME}
-    else
         cd ${NAME}
+        git checkout $BRANCH
+        cd ..
+    else
+        echo "Updating ${NAME} FROM ${REPO} on branch ${BRANCH}"
+        cd ${NAME}
+        git remote set-url origin $REPO
+        git checkout $BRANCH
         echo ${NAME} `git pull`
         cd ..
 	fi
 }
 
-update_repo_ssh()
-{
-	NAME=$1
-	REPO="git@github.com:me-box/${NAME}.git"
+while read comp; do
+  if [ "$comp" != "" ]
+  then 
+    update_repo $comp &
+  fi
+done <databox-components
 
-	if [ ! -d ${NAME} ]; then
-        git clone ${REPO} ${NAME}
-    else
-        cd ${NAME}
-        echo ${NAME} `git pull`
-        cd ..
-	fi
-}
-
-update_repo "core-container-manager" &
-update_repo "core-arbiter" &
-update_repo "core-export-service" &
-update_repo "platform-app-server" &
-update_repo "store-json" &
-update_repo "store-timeseries" &
-
-update_repo "driver-os-monitor" &
-update_repo "driver-twitter" &
-update_repo "driver-sensingkit" &
-update_repo "driver-google-takeout" &
-update_repo "driver-phillips-hue" &
-update_repo "driver-tplink-smart-plug" &
-
-update_repo "app-twitter-sentiment" & 
-update_repo "app-light-graph" &
-update_repo "app-os-monitor" &
 wait

--- a/databox-pin
+++ b/databox-pin
@@ -1,25 +1,30 @@
 #!/bin/bash
 
-function fail {
+fail() {
     echo -e "[ERROR] ${1}"
     exit 1
 }
 
-function assert {
+assert() {
   if [ "$1" != "$2" ]
   then
     fail "$3" "$1"
   fi
 }
 
-if [ $# != 1 ]  # Must have 1 args.
-then
+usage() {
+  echo $#
   echo "Please invoke this script with the relative path to the databox component you would like to pin."
   echo "Usage: databox-pin [OPTION...] [COMPONENT DIR]"
   echo "Flags:"
   echo "-d     Delete the pin"
   echo "-h     This help message"
   exit 1
+}
+
+if [[ $# < 1 ]] || [[ "$1" == "-h" ]]  # Must have more than 1 args.
+then
+  usage
 fi  
 
 update_file() {
@@ -43,6 +48,24 @@ add_entry() {
     echo "Are you sure you want to pin ${COMPONENT_NAME} to ${ORIGIN} ${BRANCH}? [y/n]"
     read -n1 ANS
     check_y $ANS
+
+    cd $COMPONENT_DIR >/dev/null 2>&1
+    assert $? 0 "directory (${COMPONENT_DIR}) not found"
+
+    git status >/dev/null 2>&1
+    assert $? 0 "directory (${COMPONENT_DIR}) is not a git repo."
+
+    ORIGIN=$(git remote get-url --push origin)
+    #convert ssh to https pins 
+    ORIGIN=${ORIGIN//git@/https:\/\/}
+    ORIGIN=${ORIGIN//com:/com\/}
+
+    BRANCH=$(git rev-parse --abbrev-ref HEAD)
+
+    cd ..
+
+    update_file $DATABOX_CONFIG_FILE $COMPONENT_NAME "$COMPONENT_NAME $ORIGIN $BRANCH"
+
     echo "Done pined ${COMPONENT_NAME} to ${ORIGIN} ${BRANCH}"
 }
 
@@ -50,31 +73,36 @@ del_entry() {
     echo "Are you sure you want to unpin ${COMPONENT_NAME}? [y/n]"
     read -n1 ANS
     check_y $ANS
-    echo "Done pined ${COMPONENT_NAME} to ${ORIGIN} ${BRANCH}"
+
+    ORIGIN="https://github.com/me-box/${COMPONENT_NAME}"
+    BRANCH="master"
+    update_file $DATABOX_CONFIG_FILE $COMPONENT_NAME "$COMPONENT_NAME $ORIGIN $BRANCH"
+
+    echo "Done unpined ${COMPONENT_NAME}"
 }
 
 DATABOX_CONFIG_FILE=databox-components
 
-DATABOX_DIR=${pwd}
-COMPONENT_DIR=${1}
-COMPONENT_NAME=${1//.\//}
-COMPONENT_NAME=${COMPONENT_NAME%/}
 
-cd $COMPONENT_DIR >/dev/null 2>&1
-assert $? 0 "directory (${COMPONENT_DIR}) not found"
 
-git status >/dev/null 2>&1
-assert $? 0 "directory (${COMPONENT_DIR}) is not a git repo."
 
-ORIGIN=$(git remote get-url --push origin)
-#convert ssh to https pins 
-ORIGIN=${ORIGIN//git@/https:\/\/}
-ORIGIN=${ORIGIN//com:/com\/}
+if [[ "$1" == "-d" ]]
+then 
+  shift
+  DATABOX_DIR=${pwd}
+  COMPONENT_DIR=${1}
+  COMPONENT_NAME=${1//.\//}
+  COMPONENT_NAME=${COMPONENT_NAME%/}
+  del_entry
+else
+  DATABOX_DIR=${pwd}
+  COMPONENT_DIR=${1}
+  COMPONENT_NAME=${1//.\//}
+  COMPONENT_NAME=${COMPONENT_NAME%/}
+  add_entry
+fi 
 
-BRANCH=$(git rev-parse --abbrev-ref HEAD)
 
-cd ..
 
-update_file $DATABOX_CONFIG_FILE $COMPONENT_NAME "$COMPONENT_NAME $ORIGIN $BRANCH"
 
 

--- a/databox-pin
+++ b/databox-pin
@@ -1,0 +1,80 @@
+#!/bin/bash
+
+function fail {
+    echo -e "[ERROR] ${1}"
+    exit 1
+}
+
+function assert {
+  if [ "$1" != "$2" ]
+  then
+    fail "$3" "$1"
+  fi
+}
+
+if [ $# != 1 ]  # Must have 1 args.
+then
+  echo "Please invoke this script with the relative path to the databox component you would like to pin."
+  echo "Usage: databox-pin [OPTION...] [COMPONENT DIR]"
+  echo "Flags:"
+  echo "-d     Delete the pin"
+  echo "-h     This help message"
+  exit 1
+fi  
+
+update_file() {
+    FILE=$1
+    COMP=$2
+    LINE=$3
+    LEFT=$(grep -v "^${COMP}" $FILE) 
+    echo "$LEFT" > $FILE
+    echo -e $LINE >> $FILE
+}
+
+check_y() {
+    if [ $1 != "y" ]
+    then 
+        echo "OK - no changes made"
+    exit 0
+    fi
+}
+
+add_entry() {
+    echo "Are you sure you want to pin ${COMPONENT_NAME} to ${ORIGIN} ${BRANCH}? [y/n]"
+    read -n1 ANS
+    check_y $ANS
+    echo "Done pined ${COMPONENT_NAME} to ${ORIGIN} ${BRANCH}"
+}
+
+del_entry() {
+    echo "Are you sure you want to unpin ${COMPONENT_NAME}? [y/n]"
+    read -n1 ANS
+    check_y $ANS
+    echo "Done pined ${COMPONENT_NAME} to ${ORIGIN} ${BRANCH}"
+}
+
+DATABOX_CONFIG_FILE=databox-components
+
+DATABOX_DIR=${pwd}
+COMPONENT_DIR=${1}
+COMPONENT_NAME=${1//.\//}
+COMPONENT_NAME=${COMPONENT_NAME%/}
+
+cd $COMPONENT_DIR >/dev/null 2>&1
+assert $? 0 "directory (${COMPONENT_DIR}) not found"
+
+git status >/dev/null 2>&1
+assert $? 0 "directory (${COMPONENT_DIR}) is not a git repo."
+
+ORIGIN=$(git remote get-url --push origin)
+#convert ssh to https pins 
+ORIGIN=${ORIGIN//git@/https:\/\/}
+ORIGIN=${ORIGIN//com:/com\/}
+
+BRANCH=$(git rev-parse --abbrev-ref HEAD)
+
+cd ..
+
+update_file $DATABOX_CONFIG_FILE $COMPONENT_NAME "$COMPONENT_NAME $ORIGIN $BRANCH"
+
+


### PR DESCRIPTION
When working on databox it is likely that your changes will be in several repos. So when submitting a PR for the tests to pass you will need to pin those components.

Set up your working tree then use the ./databox-pin command to pin your repos (or you can edit the databox-components file directly).

eg ./databox-pin ./core-container-manager

will pin the container-manager to its current repo and branch by updating databox-components.

Once the PR has passed its test and been merged, the components should be pinned back to the repos owned by the me-box team.