### PR TITLE
run as current user

### DIFF
--- a/databox-start
+++ b/databox-start
@@ -112,6 +112,7 @@ export DATABOX_VERSION=$DATABOX_VERSION
 
 function _exec {
   docker run \
+         --user "$(id -u $(whoami))" \
          --net=host -ti --rm -v "$(pwd -P)":/cwd -w /cwd \
          $DARGS $NODE_IMAGE "$@"
 }


### PR DESCRIPTION
when running in a system where uid is not 1000, `_exec` will not be able to modify mapped volumes,
so local `node_modules` or certificates will not be created,
solve this by passing `--user` option to `docker run`