### PR TITLE
Make databox work as a systemd service on Ubuntu

### DIFF
--- a/databox-install-ubuntu-service
+++ b/databox-install-ubuntu-service
@@ -1,0 +1,28 @@
+
+PWD=$(pwd)
+SERVICE=`cat <<EOF
+[Unit]
+Description=Databox Service
+After=docker
+Requires=docker.socket
+
+[Service]
+User=root
+Group=root
+WorkingDirectory=/
+ExecStartPre=${PWD}/databox-stop
+ExecStart=${PWD}/databox-start
+ExecStop=${PWD}/databox-stop
+
+[Install]
+WantedBy=multi-user.target
+EOF
+`
+
+echo "$SERVICE"
+
+echo "$SERVICE" > /etc/systemd/system/databox.service
+
+systemctl daemon-reload
+systemctl enable databox.service
+

--- a/databox-start
+++ b/databox-start
@@ -1,5 +1,11 @@
 #!/bin/bash
 
+#makesure we are in the right dir 
+MY_PATH="`dirname \"$0\"`"              # relative
+MY_PATH="`( cd \"$MY_PATH\" && pwd )`"  # absolutized and normalized
+cd "${MY_PATH}"
+export DATABOX_PATH="${MY_PATH}"
+
 #include helper functions
 source ./scripts/utils.sh
 
@@ -55,7 +61,7 @@ assert_or_die $? 1 "Databox is already running!"
 
 ## extract a host interface IP address
 err "extracting host interface IP address ..."
-ips=($(ifconfig | grep "inet " | grep -v 127.0.0.1|awk 'match($0, /([0-9]+\.[0-9]+\.[0-9]+\.[0-9]+)/) {print substr($0,RSTART,RLENGTH)}'))
+ips=($(ifconfig | grep "inet " | grep -v 127.0.0.1 | grep -v 172. |awk 'match($0, /([0-9]+\.[0-9]+\.[0-9]+\.[0-9]+)/) {print substr($0,RSTART,RLENGTH)}'))
 EXT_IP=${ips}
 if [[ "${#ips[@]}" -gt "1" ]]; then
   err "More than one IP found! Please select one:"
@@ -123,17 +129,17 @@ export DATABOX_CORE_IMAGE_VERSION=${DATABOX_CORE_IMAGE_VERSION}
 
 function _exec {
   docker run \
-         --net=host -ti --rm -v "$(pwd -P)":/cwd -w /cwd \
+         --net=host -i --rm -v ${MY_PATH}:/cwd -w /cwd \
          ${DARGS} ${NODE_IMAGE} "$@"
 }
 
-if [ ! -d "node_modules" ]; then
+if [ ! -d "${MY_PATH}/node_modules" ]; then
   _exec npm install -loglevel silent
 fi
 
 
 
-if [ -d "./certs" ] && [ ! -f "./certs/app-server.pem" ]; then
+if [ -d "${MY_PATH}/certs" ] && [ ! -f "${MY_PATH}/certs/app-server.pem" ]; then
     echo "******************* Important Message *************************"
     echo "*    You are upgrading from an old version of databox.        *"
     echo "*    Your certificates need to be regenerated, and            *"

--- a/databox-stop
+++ b/databox-stop
@@ -1,5 +1,10 @@
 #!/bin/bash
 
+#makesure we are in the right dir 
+MY_PATH="`dirname \"$0\"`"              # relative
+MY_PATH="`( cd \"$MY_PATH\" && pwd )`"  # absolutized and normalized
+cd "${MY_PATH}"
+
 #include helper functions
 source ./scripts/utils.sh
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -9,10 +9,10 @@ services:
             - '80:80'
         volumes:
             - '/var/run/docker.sock:/var/run/docker.sock'
-            - './docker-compose.yaml:/cfg/docker-compose.yaml'
-            - './src/config.json:/cfg/config.json'
-            - './certs:/certs'
-            - './.resolv.conf:/etc/resolv.conf'
+            - '${DATABOX_PATH}/docker-compose.yaml:/cfg/docker-compose.yaml'
+            - '${DATABOX_PATH}/src/config.json:/cfg/config.json'
+            - '${DATABOX_PATH}/certs:/certs'
+            - '${DATABOX_PATH}/.resolv.conf:/etc/resolv.conf'
         environment:
             - 'DATABOX_ARBITER_ENDPOINT=https://arbiter:8080'
             - 'DATABOX_DEV=${DATABOX_DEV}'
@@ -78,21 +78,21 @@ services:
 
 secrets:
   DATABOX_ROOT_CA:
-    file: ./certs/containerManager.crt
+    file: ${DATABOX_PATH}/certs/containerManager.crt
   CM_KEY:
-    file: ./certs/arbiterToken-container-manager
+    file: ${DATABOX_PATH}/certs/arbiterToken-container-manager
   DATABOX_CM.pem:
-    file: ./certs/containerManager.pem
+    file: ${DATABOX_PATH}/certs/containerManager.pem
   DATABOX_ARBITER.pem:
-    file: ./certs/arbiter.pem
+    file: ${DATABOX_PATH}/certs/arbiter.pem
   DATABOX_EXPORT_SERVICE_PEM.json:
-    file: ./certs/export-service.json
+    file: ${DATABOX_PATH}/certs/export-service.json
   DATABOX_EXPORT_SERVICE.pem:
-    file: ./certs/export-service.pem
+    file: ${DATABOX_PATH}/certs/export-service.pem
   DATABOX_EXPORT_SERVICE_KEY:
-    file: ./certs/arbiterToken-export-service
+    file: ${DATABOX_PATH}/certs/arbiterToken-export-service
   DATABOX_NETWORK_KEY:
-    file: ./certs/arbiterToken-databox-network
+    file: ${DATABOX_PATH}/certs/arbiterToken-databox-network
 
 networks:
     databox-system-net:


### PR DESCRIPTION
just run `./databox-install-ubuntu-service` to set up databox to run as a system service. 

Tested on Ubuntu 16.04 LTS

fixes https://github.com/me-box/databox/issues/225