### PR TITLE
enable broadcast traffic relay

### DIFF
--- a/databox-build-core
+++ b/databox-build-core
@@ -25,7 +25,16 @@ build()
 {
     echo "[$(datef) $ME]: Starting build ${1} ..."
     cd $1
-    OUTPUT=$(docker build -t $2 -f Dockerfile${DATABOX_ARCH} .)
+
+    DOCKERFILE=""
+    if [ -z "$3" ]
+    then
+      DOCKERFILE="Dockerfile${DATABOX_ARCH}"
+    else
+      DOCKERFILE="${3}${DATABOX_ARCH}"
+    fi
+
+    OUTPUT=$(docker build -t $2 -f ${DOCKERFILE} .)
     test_assert $? 0 "Build ${1}" "$OUTPUT"
     cd ..
 }
@@ -36,3 +45,4 @@ build "core-arbiter" "arbiter"
 build "core-export-service" "export-service"
 build "core-store" "core-store"
 build "core-network" "core-network"
+build "core-network" "core-network-relay" "Dockerfile-relay"

--- a/databox-components
+++ b/databox-components
@@ -3,4 +3,4 @@ core-export-service https://github.com/me-box/core-export-service.git master
 core-store https://github.com/me-box/core-store.git master
 platform-app-server https://github.com/me-box/platform-app-server.git master
 core-container-manager https://github.com/me-box/core-container-manager.git master
-core-network https://github.com/me-box/core-network.git master
+core-network https://github.com/me-box/core-network.git bcast

--- a/databox-components
+++ b/databox-components
@@ -3,4 +3,4 @@ core-export-service https://github.com/me-box/core-export-service.git master
 core-store https://github.com/me-box/core-store.git master
 platform-app-server https://github.com/me-box/platform-app-server.git master
 core-container-manager https://github.com/me-box/core-container-manager.git master
-core-network https://github.com/me-box/core-network.git bcast
+core-network https://github.com/me-box/core-network.git master

--- a/databox-start
+++ b/databox-start
@@ -192,6 +192,14 @@ err "Starting Databox"
 
 docker network create -d overlay --attachable databox-system-net
 
+BCAST_FIFO="/tmp/databox_relay"
+export BCAST_FIFO=${BCAST_FIFO}
+export BCAST_IP=${EXT_IP}
+
+if [ ! -p "${BCAST_FIFO}" ]; then
+  mkfifo ${BCAST_FIFO}
+fi
+
 docker-compose -f ./docker-core-network.yaml up -d
 _exec node ./src/createResolvConf.js "$(docker inspect $(docker ps -q --filter="name=databox-network"))"
 

--- a/databox-stop
+++ b/databox-stop
@@ -60,6 +60,8 @@ err "Stopping and Removing databox-bridge ..."
 docker-compose -f ./docker-core-network.yaml down
 err "Removing network databox-system-net ..."
 docker network rm databox-system-net >/dev/null 2>&1
+err "Deleting broadcast relay fifo ..."
+rm /tmp/databox_relay
 
 err "Waiting ..."
 sleep 10 # give docker some time to remove the networks etc

--- a/docker-core-network.yaml
+++ b/docker-core-network.yaml
@@ -10,8 +10,17 @@ services:
     volumes:
       - './certs/arbiterToken-databox-network:/run/secrets/DATABOX_NETWORK_KEY'
       - './certs/databox-network.pem:/run/secrets/DATABOX_NETWORK.pem'
+      - '${BCAST_FIFO}:/tmp/relay'
+    command: ["-f", "/tmp/relay"]
     cap_add:
       - NET_ADMIN
+
+  databox-broadcast-relay:
+    image: ${DOCKER_REPO}core-network-relay:${DATABOX_CORE_IMAGE_VERSION}
+    network_mode: "host"
+    volumes:
+      - '${BCAST_FIFO}:/tmp/relay'
+    command: ["-f", "/tmp/relay", "-h", "${BCAST_IP}"]
 
 networks:
   databox-system-net:


### PR DESCRIPTION
together with changes from [core-network#bcast](https://github.com/me-box/core-network/tree/bcast) to enable broadcast traffic relay to drivers' and apps' networks

another helper service databox-broadcast-relay will be started together with core-network, the host docker network is attached to this new service's container, this way all the interfaces from the host will be mapped into that container. The relay utility within the new service's container will choose the interface whose IP matches the value given to `-h` to listen, and only relay link local broadcast traffic to the fifo, given by `-f`.

tested by installing tcpdump into a driver, then capturing and comparing the broadcast traffic with those captured from host network